### PR TITLE
Revert "theme update body3 to have display inline-block"

### DIFF
--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -51,7 +51,6 @@ const typography: TypographyVariantsOptions = {
     fontSize: "12px",
     lineHeight: "18px",
     letterSpacing: "0.15px",
-    display: "inline-block",
   },
   subtitle1: {
     fontSize: "16px",


### PR DESCRIPTION
Reverts zesty-io/material#90

@shrunyan  @agalin920  

for some reason, after checking this on stage the recent changes causes breaking changes in other part of the pages the uses body3, this PR would revert that changes

