### PR TITLE
Fix standard alert text colors

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -410,6 +410,9 @@ const components: Components = {
         " .MuiAlert-icon": {
           color: theme.palette.warning.dark,
         },
+        "& .MuiAlert-message": {
+          color: theme.palette.warning.dark,
+        },
       }),
       standardInfo: ({ theme }: { theme: any }) => ({
         backgroundColor: theme.palette.blue[100],
@@ -423,6 +426,9 @@ const components: Components = {
       standardError: ({ theme }: { theme: any }) => ({
         backgroundColor: alpha(theme.palette.error.main, 0.1),
         " .MuiAlert-icon": {
+          color: theme.palette.error.main,
+        },
+        "& .MuiAlert-message": {
           color: theme.palette.error.main,
         },
       }),


### PR DESCRIPTION
A [recent PR](https://github.com/zesty-io/material/pull/99) caused all the alert text colors to always be white making them unreadable for standard variant alerts.

![alert](https://github.com/zesty-io/material/assets/28705606/b11c4566-8c84-44c2-8d14-6e6771e4b7c0)
