### PR TITLE
Update color pallete and toggle button component

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -689,11 +689,11 @@ const components: Components = {
     },
   },
   MuiToggleButton: {
-    styleOverrides: {
+    styleOverrides: ({ theme }: { theme: any }) => ({
       sizeSmall: {
-        fontSize: "16px",
+        ...theme.typography.body2,
       },
-    },
+    }),
   },
   MuiListItemText: {
     styleOverrides: {

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -36,6 +36,7 @@ const lightThemePalette: PaletteOptions = {
     main: "#12B76A",
     dark: "#027A48",
     light: "#D1FADF",
+	contrastText: "#ffffff",
   },
   warning: {
     main: "#F79009",
@@ -51,6 +52,7 @@ const lightThemePalette: PaletteOptions = {
     main: "#0BA5EC",
     dark: "#026AA2",
     light: "#7CD4FD",
+	contrastText: "#ffffff",
   },
   text: {
     primary: "#101828",
@@ -167,11 +169,11 @@ const lightThemePalette: PaletteOptions = {
   },
   border: "#F2F4F7",
   action: {
-    active: "rgba(16, 24, 40, 0.40)",
+    active: "rgba(127, 127, 126, 0.6)",
     hover: "rgba(16, 24, 40, 0.04)",
-    selected: "rgba(16, 24, 40, 0.08)",
-    disabled: "rgba(16, 24, 40, 0.26)",
-    disabledBackground: "rgba(16, 24, 40, 0.12)",
+    selected: "rgba(127,127, 126, 0.13)",
+	disabled: "rgba(127,127, 126, 0.48)",
+	disabledBackground: "rgba(127,127, 126, 0.2)",
     focus: "rgba(16, 24, 40, 0.12)",
   },
 };

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -36,7 +36,7 @@ const lightThemePalette: PaletteOptions = {
     main: "#12B76A",
     dark: "#027A48",
     light: "#D1FADF",
-	contrastText: "#ffffff",
+    contrastText: "#ffffff",
   },
   warning: {
     main: "#F79009",
@@ -52,7 +52,7 @@ const lightThemePalette: PaletteOptions = {
     main: "#0BA5EC",
     dark: "#026AA2",
     light: "#7CD4FD",
-	contrastText: "#ffffff",
+    contrastText: "#ffffff",
   },
   text: {
     primary: "#101828",
@@ -172,8 +172,8 @@ const lightThemePalette: PaletteOptions = {
     active: "rgba(127, 127, 126, 0.6)",
     hover: "rgba(16, 24, 40, 0.04)",
     selected: "rgba(127,127, 126, 0.13)",
-	disabled: "rgba(127,127, 126, 0.48)",
-	disabledBackground: "rgba(127,127, 126, 0.2)",
+    disabled: "rgba(127,127, 126, 0.48)",
+    disabledBackground: "rgba(127,127, 126, 0.2)",
     focus: "rgba(16, 24, 40, 0.12)",
   },
 };


### PR DESCRIPTION
- Update the "success" and "info" options in the theme palette to ensure the correct "contrastText" is applied.
- Modify the "MuiToggleButton" to set the font size of the small variant to "14px" for consistency with other components' small variants.
- Updated the "active," "selected," "disabled," and "disabledBackground" states to enhance visibility when components are placed on the "grey.900" background, commonly used in navigation bars and code app's heading and drawer.

**Note:**
Replaced the colors with alternatives that maintain the same appearance but with different contrast levels, ensuring visibility in both dark and light themes without altering the overall UI color scheme.

**Below are the changes before and after they were applied:**

![image](https://github.com/user-attachments/assets/698a827c-0c77-4bb7-ad71-676ecbf05c13)


